### PR TITLE
Use idle event instead of debounce hack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var MapboxGl = require('mapbox-gl');
 var styleSpec = require("mapbox-gl/src/style-spec/reference/v8.json");
-var debounce = require("lodash.debounce");
 var PCancelable = require('p-cancelable');
 
 

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ var toBlob = function fn(opts, mimeType, qualityArgument) {
   Object.defineProperty(fn, 'name', { writable: true });
   var uniqueKey = "mapboxGlToBlob_"+Math.random().toString(36).substr(2, 9);
   fn.name = uniqueKey;
-  
+
   // Copy opts for safety
   var outOpts = opts.output;
   var glOpts = Object.assign({
@@ -134,11 +134,11 @@ var toBlob = function fn(opts, mimeType, qualityArgument) {
             // HACK: We throw an error so we can see if we (this library)
             // is in the stack trace. This means that `window.devicePixelRatio`
             // will continue to function as normal in other code running on the
-            // page. 
+            // page.
             try {
               throw new Error();
             }
-            catch (e) { 
+            catch (e) {
               if(e.stack.indexOf(uniqueKey)) {
                 return outOpts.dpi / 96;
               }
@@ -180,10 +180,6 @@ var toBlob = function fn(opts, mimeType, qualityArgument) {
 
         var called = false;
         function onMapRendered() {
-          // Always wait for loaded event
-          if(!loaded) {
-            return;
-          }
           if(called) {
             return;
           }
@@ -199,17 +195,9 @@ var toBlob = function fn(opts, mimeType, qualityArgument) {
           }
         }
 
-        /**
-         * While mapbox-gl-js is doing layout we appear to get multiple 'render' events after the 'load' event. Assuming all the loading has happened already we debounce our onMapRendered method by 1 second to allow all render events to take place.
-         *
-         * This is a bit of a hack, however the theroy is that a 1 second debounce should be vastly greater than the length of time it'll take to complete this action.
-         */
-        const debouncedRender = debounce(onMapRendered, 1000);
-
         function cleanUp() {
           map.remove();
           removeEl(hidden);
-          debouncedRender.cancel();
           Object.defineProperty(window, 'devicePixelRatio', {
             get: function() {
               return actualPixelRatio
@@ -221,13 +209,7 @@ var toBlob = function fn(opts, mimeType, qualityArgument) {
           cleanUp();
         })
 
-        map.on('render', debouncedRender);
-
-        map.once('load', function() {
-          loaded = true;
-          // We may or may not get another render event.
-          debouncedRender();
-        });
+        map.once('idle', onMapRendered);
       })
   });
 
@@ -239,3 +221,4 @@ module.exports = {
   toBlob: toBlob,
   toPixels: toPixels
 };
+

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/orangemug/mapbox-gl-to-blob/issues"
   },
   "peerDependencies": {
-    "mapbox-gl": ">v0.52.0-beta.1"
+    "mapbox-gl": ">0.52.0"
   },
   "eslintConfig": {
     "parserOptions": {
@@ -39,7 +39,7 @@
     }
   },
   "devDependencies": {
-    "mapbox-gl": "^v0.52.0-beta.1",
+    "mapbox-gl": "^0.52.0",
     "webpack": "^4.26.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.10"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/orangemug/mapbox-gl-to-blob/issues"
   },
   "peerDependencies": {
-    "mapbox-gl": ">0.44.1"
+    "mapbox-gl": ">v0.52.0-beta.1"
   },
   "eslintConfig": {
     "parserOptions": {
@@ -39,13 +39,12 @@
     }
   },
   "devDependencies": {
-    "mapbox-gl": "^0.45.0",
-    "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.14",
-    "webpack-dev-server": "^3.1.3"
+    "mapbox-gl": "^v0.52.0-beta.1",
+    "webpack": "^4.26.1",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.10"
   },
   "dependencies": {
-    "lodash.debounce": "^4.0.8",
     "p-cancelable": "^0.4.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  mode: 'production',
+  mode: 'development',
   entry: './example/app.js',
   output: {
 		path: path.resolve(__dirname, 'dist'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+  mode: 'production',
   entry: './example/app.js',
   output: {
 		path: path.resolve(__dirname, 'dist'),
@@ -10,3 +11,4 @@ module.exports = {
     minimize: false
   }
 };
+


### PR DESCRIPTION
There is now an [`idle`](https://github.com/mapbox/mapbox-gl-js/blob/1b8ca116b0a27d8b1ea546132c06901a5e2b1d68/src/ui/events.js#L680-L692) event available, which could be used instead of the debounce hack:

> Fired after the last frame rendered before the map enters an "idle" state:
>       - No camera transitions are in progress
>       - All currently requested tiles have loaded
>       - All fade/transition animations have completed

Also updated the deps.

Ref #1